### PR TITLE
Retract version number from Composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "transferzero/transferzero-php-sdk",
-    "version": "1.2.0",
     "description": "TransferZero Client Library for PHP",
     "homepage": "http://api.transferzero.com/documentation",
     "license": "MIT",


### PR DESCRIPTION
This PR retracts the version number from the `1.2.0`
`composer.json` based on the assumption that the
latest changes will be auto recognised by packagist.org, 
when the version number is not specified. 